### PR TITLE
Add custom HTTP headers support to download requests

### DIFF
--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/DownloadRequest.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/DownloadRequest.kt
@@ -7,7 +7,8 @@ data class DownloadRequest(
   val url: String,
   val destPath: Path,
   val taskId: String = generateTaskId(),
-  val connections: Int = 4
+  val connections: Int = 4,
+  val headers: Map<String, String> = emptyMap()
 ) {
   init {
     require(url.isNotBlank()) { "URL must not be blank" }

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/HttpEngine.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/HttpEngine.kt
@@ -3,11 +3,12 @@ package com.linroid.kdown
 import com.linroid.kdown.model.ServerInfo
 
 interface HttpEngine {
-  suspend fun head(url: String): ServerInfo
+  suspend fun head(url: String, headers: Map<String, String> = emptyMap()): ServerInfo
 
   suspend fun download(
     url: String,
     range: LongRange?,
+    headers: Map<String, String> = emptyMap(),
     onData: suspend (ByteArray) -> Unit
   )
 

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/internal/RangeSupportDetector.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/internal/RangeSupportDetector.kt
@@ -6,7 +6,7 @@ import com.linroid.kdown.model.ServerInfo
 internal class RangeSupportDetector(
   private val httpEngine: HttpEngine
 ) {
-  suspend fun detect(url: String): ServerInfo {
-    return httpEngine.head(url)
+  suspend fun detect(url: String, headers: Map<String, String> = emptyMap()): ServerInfo {
+    return httpEngine.head(url, headers)
   }
 }

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/internal/SegmentDownloader.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/internal/SegmentDownloader.kt
@@ -13,6 +13,7 @@ internal class SegmentDownloader(
   suspend fun download(
     url: String,
     segment: Segment,
+    headers: Map<String, String> = emptyMap(),
     onProgress: suspend (bytesDownloaded: Long) -> Unit
   ): Segment {
     if (segment.isComplete) {
@@ -22,7 +23,7 @@ internal class SegmentDownloader(
     var downloadedBytes = segment.downloadedBytes
     val range = segment.currentOffset..segment.end
 
-    httpEngine.download(url, range) { data ->
+    httpEngine.download(url, range, headers) { data ->
       coroutineContext.ensureActive()
 
       val writeOffset = segment.start + downloadedBytes

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/model/DownloadMetadata.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/model/DownloadMetadata.kt
@@ -33,6 +33,7 @@ data class DownloadMetadata(
   val etag: String?,
   val lastModified: String?,
   val segments: List<Segment>,
+  val headers: Map<String, String> = emptyMap(),
   val createdAt: Long,
   val updatedAt: Long
 ) {

--- a/library/core/src/commonTest/kotlin/com/linroid/kdown/DownloadMetadataTest.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/kdown/DownloadMetadataTest.kt
@@ -128,4 +128,40 @@ class DownloadMetadataTest {
     assertEquals(0, metadata.segments[0].downloadedBytes)
     assertEquals(2000L, metadata.updatedAt)
   }
+
+  @Test
+  fun defaultHeaders_isEmpty() {
+    val metadata = createMetadata()
+    assertEquals(emptyMap(), metadata.headers)
+  }
+
+  @Test
+  fun serializationRoundTrip_withHeaders() {
+    val headers = mapOf("Authorization" to "Bearer token", "X-Custom" to "value")
+    val original = createMetadata().copy(headers = headers)
+    val serialized = json.encodeToString(DownloadMetadata.serializer(), original)
+    val deserialized = json.decodeFromString<DownloadMetadata>(serialized)
+    assertEquals(original, deserialized)
+    assertEquals(headers, deserialized.headers)
+  }
+
+  @Test
+  fun deserialization_withoutHeaders_defaultsToEmpty() {
+    val jsonStr = """
+      {
+        "taskId": "t1",
+        "url": "https://example.com/f",
+        "destPath": "/tmp/f",
+        "totalBytes": 100,
+        "acceptRanges": false,
+        "etag": null,
+        "lastModified": null,
+        "segments": [],
+        "createdAt": 0,
+        "updatedAt": 0
+      }
+    """.trimIndent()
+    val metadata = json.decodeFromString<DownloadMetadata>(jsonStr)
+    assertEquals(emptyMap(), metadata.headers)
+  }
 }

--- a/library/core/src/commonTest/kotlin/com/linroid/kdown/DownloadRequestTest.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/kdown/DownloadRequestTest.kt
@@ -54,4 +54,23 @@ class DownloadRequestTest {
       DownloadRequest(url = "https://example.com/file", destPath = Path("/tmp/file"), connections = -1)
     }
   }
+
+  @Test
+  fun defaultHeaders_isEmpty() {
+    val request = DownloadRequest(url = "https://example.com/file", destPath = Path("/tmp/file"))
+    assertEquals(emptyMap(), request.headers)
+  }
+
+  @Test
+  fun customHeaders_preserved() {
+    val headers = mapOf("Authorization" to "Bearer token123", "X-Custom" to "value")
+    val request = DownloadRequest(
+      url = "https://example.com/file",
+      destPath = Path("/tmp/file"),
+      headers = headers
+    )
+    assertEquals(headers, request.headers)
+    assertEquals("Bearer token123", request.headers["Authorization"])
+    assertEquals("value", request.headers["X-Custom"])
+  }
 }

--- a/library/core/src/commonTest/kotlin/com/linroid/kdown/FakeHttpEngine.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/kdown/FakeHttpEngine.kt
@@ -25,11 +25,16 @@ class FakeHttpEngine(
     private set
   var downloadCallCount = 0
     private set
+  var lastHeadHeaders: Map<String, String> = emptyMap()
+    private set
+  var lastDownloadHeaders: Map<String, String> = emptyMap()
+    private set
   var closed = false
     private set
 
-  override suspend fun head(url: String): ServerInfo {
+  override suspend fun head(url: String, headers: Map<String, String>): ServerInfo {
     headCallCount++
+    lastHeadHeaders = headers
     if (failOnHead) {
       throw KDownError.Network(RuntimeException("Simulated network failure"))
     }
@@ -42,9 +47,11 @@ class FakeHttpEngine(
   override suspend fun download(
     url: String,
     range: LongRange?,
+    headers: Map<String, String>,
     onData: suspend (ByteArray) -> Unit
   ) {
     downloadCallCount++
+    lastDownloadHeaders = headers
 
     if (httpErrorCode > 0) {
       throw KDownError.Http(httpErrorCode, "Simulated HTTP error")

--- a/library/core/src/commonTest/kotlin/com/linroid/kdown/internal/RangeSupportDetectorTest.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/kdown/internal/RangeSupportDetectorTest.kt
@@ -75,4 +75,13 @@ class RangeSupportDetectorTest {
     detector.detect("https://example.com/file")
     assertEquals(1, engine.headCallCount)
   }
+
+  @Test
+  fun detect_passesCustomHeaders() = runTest {
+    val engine = FakeHttpEngine()
+    val detector = RangeSupportDetector(engine)
+    val headers = mapOf("Authorization" to "Bearer token", "X-Custom" to "value")
+    detector.detect("https://example.com/file", headers)
+    assertEquals(headers, engine.lastHeadHeaders)
+  }
 }


### PR DESCRIPTION
## Summary
This PR adds support for custom HTTP headers in download requests, allowing users to pass authentication tokens, custom headers, and other HTTP metadata through the download pipeline.

## Key Changes
- **DownloadRequest**: Added optional `headers` parameter (defaults to empty map) to allow users to specify custom HTTP headers when creating a download request
- **HttpEngine interface**: Updated `head()` and `download()` methods to accept optional `headers` parameter
- **DownloadMetadata**: Added `headers` field to persist custom headers across download sessions, enabling proper resume functionality with authentication
- **DownloadCoordinator**: Threaded headers through the download initialization and segment download process
- **RangeSupportDetector**: Updated to pass headers when detecting server capabilities
- **SegmentDownloader**: Updated to pass headers when downloading individual segments
- **KtorHttpEngine**: Implemented header injection in both HEAD and GET requests
- **Tests**: Added comprehensive test coverage for:
  - Default empty headers behavior
  - Custom headers preservation in DownloadRequest
  - Headers serialization/deserialization in DownloadMetadata
  - Backward compatibility (deserialization without headers field)
  - Header passing through RangeSupportDetector
  - FakeHttpEngine tracking of passed headers

## Implementation Details
- Headers are optional with sensible defaults (empty map) to maintain backward compatibility
- Headers are properly serialized/deserialized in DownloadMetadata for resume support
- Headers are consistently passed through all layers: request → coordinator → detector/downloader → HTTP engine
- The implementation supports authentication headers and any custom HTTP headers needed by the server

https://claude.ai/code/session_01Ea1EnasyjvPt8jcqHo61C6