### PR TITLE
Add allowed_bots configuration to Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
Updated the Claude code review GitHub Action workflow to explicitly configure which bots are allowed to perform code reviews.

## Changes
- Added `allowed_bots: 'claude'` parameter to the `anthropics/claude-code-action@v1` step
  - This restricts code review execution to the Claude bot only
  - Prevents unauthorized or unintended bots from triggering the code review workflow

## Details
This change enhances the security and control of the automated code review process by explicitly whitelisting the Claude bot. This ensures that only the intended bot can execute code reviews on pull requests in this repository.

https://claude.ai/code/session_01P89BkcFMvakj7Sv3ASAHNs