### PR TITLE
Fix race conditions and improve error classification

### DIFF
--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/internal/SegmentDownloader.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/internal/SegmentDownloader.kt
@@ -3,7 +3,9 @@ package com.linroid.kdown.internal
 import com.linroid.kdown.FileAccessor
 import com.linroid.kdown.HttpEngine
 import com.linroid.kdown.KDownLogger
+import com.linroid.kdown.error.KDownError
 import com.linroid.kdown.model.Segment
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ensureActive
 import kotlin.coroutines.coroutineContext
 
@@ -34,7 +36,13 @@ internal class SegmentDownloader(
       coroutineContext.ensureActive()
 
       val writeOffset = segment.start + downloadedBytes
-      fileAccessor.writeAt(writeOffset, data)
+      try {
+        fileAccessor.writeAt(writeOffset, data)
+      } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        if (e is KDownError) throw e
+        throw KDownError.Disk(e)
+      }
       downloadedBytes += data.size
       onProgress(downloadedBytes)
     }


### PR DESCRIPTION
## Summary

- **Classify I/O exceptions as `KDownError.Disk`**: `FileAccessor` operations (`writeAt`, `flush`, `preallocate`) now throw `KDownError.Disk` instead of propagating as `KDownError.Unknown`, enabling proper error handling and preventing unwanted retries
- **Guard against duplicate active downloads**: `start()`, `startFromRecord()`, and `resume()` check `activeDownloads` inside the mutex and return early if the task is already running, preventing concurrent writes to the same file
- **Validate local file integrity on resume**: New `validateLocalFile()` checks file size against claimed segment progress before resuming; resets segments and re-preallocates if file is missing or truncated
- **Add state transition guards**: Pause/resume/cancel action lambdas in `KDown` now validate current state before proceeding (e.g., no pause on completed, no resume on active)
- **Log missing TaskRecord warnings**: `updateTaskRecord()` logs a warning instead of silently returning when the record is not found
- **Log flush errors during pause**: Replace silent exception swallowing with `KDownLogger.w()` for better debuggability

## Test plan

- [x] `./gradlew :library:core:build` passes on all platforms
- [x] `./gradlew :library:core:jvmTest` passes
- [x] Verify no public API changes (all changes are internal or behavioral)
- [x] Manual test: rapid pause/resume doesn't create duplicate downloads
- [x] Manual test: deleting file during pause then resuming resets progress correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)