### PR TITLE
Fix speed-limited downloads completing with partial data

### DIFF
--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/segment/SegmentDownloader.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/segment/SegmentDownloader.kt
@@ -51,8 +51,22 @@ internal class SegmentDownloader(
       onProgress(downloadedBytes)
     }
 
+    if (downloadedBytes < segment.totalBytes) {
+      KDownLogger.w("SegmentDownloader") {
+        "Incomplete segment ${segment.index}: " +
+          "downloaded $downloadedBytes/${segment.totalBytes} bytes"
+      }
+      throw KDownError.Network(
+        Exception(
+          "Connection closed prematurely: received " +
+            "$downloadedBytes of ${segment.totalBytes} bytes"
+        )
+      )
+    }
+
     KDownLogger.d("SegmentDownloader") {
-      "Completed segment ${segment.index}: downloaded ${downloadedBytes - initialBytes} bytes"
+      "Completed segment ${segment.index}: " +
+        "downloaded ${downloadedBytes - initialBytes} bytes"
     }
 
     return segment.copy(downloadedBytes = downloadedBytes)

--- a/library/ktor/src/commonMain/kotlin/com/linroid/kdown/engine/KtorHttpEngine.kt
+++ b/library/ktor/src/commonMain/kotlin/com/linroid/kdown/engine/KtorHttpEngine.kt
@@ -3,6 +3,7 @@ package com.linroid.kdown.engine
 import com.linroid.kdown.error.KDownError
 import com.linroid.kdown.log.KDownLogger
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.head
 import io.ktor.client.request.header
 import io.ktor.client.request.prepareGet
@@ -14,7 +15,7 @@ import io.ktor.utils.io.readAvailable
 import kotlin.coroutines.cancellation.CancellationException
 
 class KtorHttpEngine(
-  private val client: HttpClient = HttpClient()
+  private val client: HttpClient = defaultClient()
 ) : HttpEngine {
 
   override suspend fun head(url: String, headers: Map<String, String>): ServerInfo {
@@ -110,5 +111,12 @@ class KtorHttpEngine(
 
   companion object {
     private const val DEFAULT_BUFFER_SIZE = 8192
+
+    private fun defaultClient(): HttpClient = HttpClient {
+      install(HttpTimeout) {
+        socketTimeoutMillis = Long.MAX_VALUE
+        requestTimeoutMillis = Long.MAX_VALUE
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- **SegmentDownloader** now validates that all expected bytes were received after the download loop. If the connection closes prematurely, throws `KDownError.Network` which triggers the retry mechanism instead of silently marking the segment as complete with partial data.
- **KtorHttpEngine** default `HttpClient` now configures `HttpTimeout` with infinite socket/request timeouts. With speed limiting, `TokenBucket.acquire()` delays slow channel consumption, causing TCP backpressure that could trigger the engine's default socket timeout and close the connection.

## Root Cause
With a speed limit (e.g. 1MB/s), the token bucket throttle delays consumption of the Ktor response channel. This causes TCP backpressure (receive window closes), and the HTTP engine's socket timeout fires because no data flows for too long. The connection closes, `channel.isClosedForRead` becomes true, and the download loop exits. Previously, `SegmentDownloader` accepted whatever bytes were received without checking — a 2.3GB download would "complete" after only 16MB.

## Test plan
- [x] Download a large file (>100MB) with `--speed-limit 1m` and verify it downloads completely
- [x] Verify retry kicks in if the connection is interrupted mid-download
- [x] Verify downloads without speed limits still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)