### PR TITLE
Add GitHub Actions workflow to deploy web app to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,49 @@
+name: Deploy Web App
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build Web App
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v5
+
+      - name: Build WasmJs distribution
+        run: ./gradlew :app:web:wasmJsBrowserDistribution
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: app/web/build/dist/wasmJs/productionExecutable
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Add `deploy-web.yml` workflow that builds the WasmJs web app and deploys it to GitHub Pages
- Triggers on push to `main` and manual `workflow_dispatch`
- Uses official `actions/upload-pages-artifact` and `actions/deploy-pages` actions

## Setup required
Go to **Settings > Pages** and set the source to **GitHub Actions**.

## Test plan
- [ ] Merge to main and verify the workflow runs successfully
- [ ] Confirm the web app is accessible at the GitHub Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)