### PR TITLE
Add start lifecycle to KDownApi backends

### DIFF
--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/backend/BackendManager.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/backend/BackendManager.kt
@@ -5,7 +5,6 @@ import com.linroid.kdown.api.DownloadTask
 import com.linroid.kdown.api.KDownApi
 import com.linroid.kdown.api.KDownVersion
 import com.linroid.kdown.api.SpeedLimit
-import com.linroid.kdown.core.KDown
 import com.linroid.kdown.remote.ConnectionState
 import com.linroid.kdown.remote.RemoteKDown
 import kotlinx.coroutines.CoroutineScope
@@ -82,8 +81,8 @@ class BackendManager(
     _serverState.asStateFlow()
 
   init {
-    if (embeddedApi is KDown) {
-      scope.launch { embeddedApi.loadTasks() }
+    embeddedApi?.let { api ->
+      scope.launch { api.start() }
     }
   }
 
@@ -130,7 +129,9 @@ class BackendManager(
     val newApi = _activeApi.value
     if (newApi is RemoteKDown) {
       observeRemoteConnectionState(entry, newApi)
-    } else {
+    }
+    newApi.start()
+    if (newApi !is RemoteKDown) {
       (entry.connectionState as? MutableStateFlow)?.value =
         ConnectionState.Connected
     }
@@ -253,5 +254,6 @@ private object DisconnectedApi : KDownApi {
   }
 
   override suspend fun setGlobalSpeedLimit(limit: SpeedLimit) {}
+  override suspend fun start() {}
   override fun close() {}
 }

--- a/app/shared/src/commonTest/kotlin/com/linroid/kdown/app/FakeKDownApi.kt
+++ b/app/shared/src/commonTest/kotlin/com/linroid/kdown/app/FakeKDownApi.kt
@@ -47,6 +47,8 @@ class FakeKDownApi(
     lastSpeedLimit = limit
   }
 
+  override suspend fun start() {}
+
   override fun close() {
     closed = true
     closeCallCount++

--- a/library/api/src/commonMain/kotlin/com/linroid/kdown/api/KDownApi.kt
+++ b/library/api/src/commonMain/kotlin/com/linroid/kdown/api/KDownApi.kt
@@ -20,6 +20,14 @@ interface KDownApi {
   /** Create a new download and return the task handle. */
   suspend fun download(request: DownloadRequest): DownloadTask
 
+  /**
+   * Initialize backend runtime state.
+   *
+   * - Core backend restores persisted tasks.
+   * - Remote backend establishes connection and syncs tasks.
+   */
+  suspend fun start()
+
   /** Set global speed limit (use [SpeedLimit.Unlimited] to remove). */
   suspend fun setGlobalSpeedLimit(limit: SpeedLimit)
 

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/core/KDown.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/core/KDown.kt
@@ -260,6 +260,10 @@ class KDown(
     return task
   }
 
+  override suspend fun start() {
+    loadTasks()
+  }
+
   /**
    * Loads all task records from the [TaskStore] and populates the
    * [tasks] flow. Does **not** auto-resume — call


### PR DESCRIPTION
## Summary
- add start() to KDownApi as backend initialization lifecycle
- implement KDown.start() by loading persisted tasks via loadTasks()
- implement RemoteKDown.start() to establish SSE connection and sync tasks
- update BackendManager to call start() for embedded init and backend switches
- update test and disconnected API implementations for the new interface

## Notes
- leaves unrelated working tree changes uncommitted
- full ./gradlew build in this environment hit Android dex OOM, but changed modules compile during build