### PR TITLE
Enhance speed limit UI with collapsible dialog panels

### DIFF
--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/state/AppState.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/state/AppState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.linroid.kdown.api.DownloadPriority
 import com.linroid.kdown.api.DownloadRequest
+import com.linroid.kdown.api.DownloadSchedule
 import com.linroid.kdown.api.DownloadState
 import com.linroid.kdown.api.DownloadTask
 import com.linroid.kdown.api.KDownApi
@@ -86,7 +87,8 @@ class AppState(
     url: String,
     fileName: String,
     speedLimit: SpeedLimit,
-    priority: DownloadPriority
+    priority: DownloadPriority,
+    schedule: DownloadSchedule = DownloadSchedule.Immediate
   ) {
     scope.launch {
       runCatching {
@@ -96,7 +98,8 @@ class AppState(
           fileName = fileName.ifBlank { null },
           connections = 4,
           speedLimit = speedLimit,
-          priority = priority
+          priority = priority,
+          schedule = schedule
         )
         activeApi.value.download(request)
       }.onFailure { e ->

--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/AppShell.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/AppShell.kt
@@ -340,11 +340,13 @@ fun AppShell(backendManager: BackendManager) {
   if (appState.showAddDialog) {
     AddDownloadDialog(
       onDismiss = { appState.showAddDialog = false },
-      onDownload = { url, fileName, speedLimit, priority ->
+      onDownload = { url, fileName, speedLimit,
+                     priority, schedule ->
         appState.showAddDialog = false
         appState.dismissError()
         appState.startDownload(
-          url, fileName, speedLimit, priority
+          url, fileName, speedLimit, priority,
+          schedule
         )
       }
     )

--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/common/PrioritySelector.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/common/PrioritySelector.kt
@@ -51,6 +51,32 @@ fun PriorityIcon(
 }
 
 @Composable
+fun PrioritySelector(
+  value: DownloadPriority,
+  onValueChange: (DownloadPriority) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Row(
+    modifier = modifier,
+    horizontalArrangement = Arrangement.spacedBy(6.dp)
+  ) {
+    DownloadPriority.entries.forEach { priority ->
+      FilterChip(
+        selected = value == priority,
+        onClick = { onValueChange(priority) },
+        label = {
+          Text(
+            text = priorityLabel(priority),
+            style =
+              MaterialTheme.typography.labelSmall
+          )
+        }
+      )
+    }
+  }
+}
+
+@Composable
 fun PriorityPanel(
   task: DownloadTask,
   scope: CoroutineScope,
@@ -59,24 +85,12 @@ fun PriorityPanel(
   var currentPriority by remember {
     mutableStateOf(task.request.priority)
   }
-  Row(
-    modifier = modifier,
-    horizontalArrangement = Arrangement.spacedBy(6.dp)
-  ) {
-    DownloadPriority.entries.forEach { priority ->
-      FilterChip(
-        selected = currentPriority == priority,
-        onClick = {
-          currentPriority = priority
-          scope.launch { task.setPriority(priority) }
-        },
-        label = {
-          Text(
-            text = priorityLabel(priority),
-            style = MaterialTheme.typography.labelSmall
-          )
-        }
-      )
-    }
-  }
+  PrioritySelector(
+    value = currentPriority,
+    onValueChange = { priority ->
+      currentPriority = priority
+      scope.launch { task.setPriority(priority) }
+    },
+    modifier = modifier
+  )
 }

--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/common/ScheduleToggle.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/common/ScheduleToggle.kt
@@ -28,11 +28,26 @@ private data class ScheduleOption(
 
 private val scheduleOptions = listOf(
   ScheduleOption("Now", DownloadSchedule.Immediate),
-  ScheduleOption("5 min", DownloadSchedule.AfterDelay(5.minutes)),
-  ScheduleOption("15 min", DownloadSchedule.AfterDelay(15.minutes)),
-  ScheduleOption("30 min", DownloadSchedule.AfterDelay(30.minutes)),
-  ScheduleOption("1 hour", DownloadSchedule.AfterDelay(1.hours)),
-  ScheduleOption("3 hours", DownloadSchedule.AfterDelay(3.hours))
+  ScheduleOption(
+    "5 min",
+    DownloadSchedule.AfterDelay(5.minutes)
+  ),
+  ScheduleOption(
+    "15 min",
+    DownloadSchedule.AfterDelay(15.minutes)
+  ),
+  ScheduleOption(
+    "30 min",
+    DownloadSchedule.AfterDelay(30.minutes)
+  ),
+  ScheduleOption(
+    "1 hour",
+    DownloadSchedule.AfterDelay(1.hours)
+  ),
+  ScheduleOption(
+    "3 hours",
+    DownloadSchedule.AfterDelay(3.hours)
+  )
 )
 
 @Composable
@@ -61,6 +76,32 @@ fun ScheduleIcon(
 }
 
 @Composable
+fun ScheduleSelector(
+  value: DownloadSchedule,
+  onValueChange: (DownloadSchedule) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Row(
+    modifier = modifier,
+    horizontalArrangement = Arrangement.spacedBy(6.dp)
+  ) {
+    scheduleOptions.forEach { option ->
+      FilterChip(
+        selected = value == option.schedule,
+        onClick = { onValueChange(option.schedule) },
+        label = {
+          Text(
+            text = option.label,
+            style =
+              MaterialTheme.typography.labelSmall
+          )
+        }
+      )
+    }
+  }
+}
+
+@Composable
 fun SchedulePanel(
   task: DownloadTask,
   scope: CoroutineScope,
@@ -83,7 +124,8 @@ fun SchedulePanel(
         label = {
           Text(
             text = option.label,
-            style = MaterialTheme.typography.labelSmall
+            style =
+              MaterialTheme.typography.labelSmall
           )
         }
       )

--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/common/SpeedLimitSlider.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/common/SpeedLimitSlider.kt
@@ -1,15 +1,21 @@
 package com.linroid.kdown.app.ui.common
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,16 +24,28 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.linroid.kdown.api.DownloadTask
 import com.linroid.kdown.api.SpeedLimit
-import com.linroid.kdown.app.util.formatBytes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-private val speedSteps = listOf(
-  0L, 512 * 1024L, 1_048_576L, 2_097_152L,
-  5_242_880L, 10_485_760L
+private data class SpeedOption(
+  val label: String,
+  val limit: SpeedLimit
+)
+
+private val presetSpeedOptions = listOf(
+  SpeedOption("Unlimited", SpeedLimit.Unlimited),
+  SpeedOption("256 KB/s", SpeedLimit.kbps(256)),
+  SpeedOption("512 KB/s", SpeedLimit.kbps(512)),
+  SpeedOption("1 MB/s", SpeedLimit.mbps(1)),
+  SpeedOption("2 MB/s", SpeedLimit.mbps(2)),
+  SpeedOption("5 MB/s", SpeedLimit.mbps(5)),
+  SpeedOption("10 MB/s", SpeedLimit.mbps(10)),
+  SpeedOption("20 MB/s", SpeedLimit.mbps(20)),
+  SpeedOption("50 MB/s", SpeedLimit.mbps(50))
 )
 
 @Composable
@@ -56,50 +74,137 @@ fun SpeedLimitIcon(
   }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun SpeedLimitSelector(
+  value: SpeedLimit,
+  onValueChange: (SpeedLimit) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val matchesPreset =
+    presetSpeedOptions.any { it.limit == value }
+  var isCustom by remember {
+    mutableStateOf(!matchesPreset)
+  }
+  var customText by remember {
+    val initial = if (!matchesPreset &&
+      !value.isUnlimited
+    ) {
+      val bps = value.bytesPerSecond
+      val mbps = bps / (1024L * 1024)
+      if (mbps > 0 && mbps * 1024 * 1024 == bps) {
+        mbps.toString()
+      } else {
+        (bps / 1024).toString()
+      }
+    } else ""
+    mutableStateOf(initial)
+  }
+  var customUnit by remember {
+    val initial = if (!matchesPreset &&
+      !value.isUnlimited
+    ) {
+      val bps = value.bytesPerSecond
+      val mbps = bps / (1024L * 1024)
+      if (mbps > 0 && mbps * 1024 * 1024 == bps) {
+        "MB/s"
+      } else "KB/s"
+    } else "MB/s"
+    mutableStateOf(initial)
+  }
+
+  Column(
+    modifier = modifier,
+    verticalArrangement = Arrangement.spacedBy(8.dp)
+  ) {
+    FlowRow(
+      horizontalArrangement =
+        Arrangement.spacedBy(8.dp),
+      verticalArrangement =
+        Arrangement.spacedBy(4.dp)
+    ) {
+      presetSpeedOptions.forEach { option ->
+        FilterChip(
+          selected = !isCustom &&
+            value == option.limit,
+          onClick = {
+            isCustom = false
+            onValueChange(option.limit)
+          },
+          label = { Text(option.label) }
+        )
+      }
+      FilterChip(
+        selected = isCustom,
+        onClick = { isCustom = true },
+        label = { Text("Custom") }
+      )
+    }
+    if (isCustom) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement =
+          Arrangement.spacedBy(8.dp)
+      ) {
+        OutlinedTextField(
+          value = customText,
+          onValueChange = { text ->
+            customText = text.filter { it.isDigit() }
+            val number = customText.toLongOrNull()
+            if (number != null && number > 0) {
+              val limit = if (customUnit == "KB/s") {
+                SpeedLimit.kbps(number)
+              } else {
+                SpeedLimit.mbps(number)
+              }
+              onValueChange(limit)
+            }
+          },
+          modifier = Modifier.width(100.dp),
+          singleLine = true,
+          placeholder = { Text("Speed") },
+          keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Number
+          )
+        )
+        FilterChip(
+          selected = customUnit == "KB/s",
+          onClick = {
+            customUnit = "KB/s"
+            val number = customText.toLongOrNull()
+            if (number != null && number > 0) {
+              onValueChange(SpeedLimit.kbps(number))
+            }
+          },
+          label = { Text("KB/s") }
+        )
+        FilterChip(
+          selected = customUnit == "MB/s",
+          onClick = {
+            customUnit = "MB/s"
+            val number = customText.toLongOrNull()
+            if (number != null && number > 0) {
+              onValueChange(SpeedLimit.mbps(number))
+            }
+          },
+          label = { Text("MB/s") }
+        )
+      }
+    }
+  }
+}
+
 @Composable
 fun SpeedLimitPanel(
   task: DownloadTask,
   scope: CoroutineScope,
   modifier: Modifier = Modifier
 ) {
-  val initial = task.request.speedLimit.bytesPerSecond
-  val initialIndex = speedSteps
-    .indexOfLast { it <= initial }
-    .coerceAtLeast(0).toFloat()
-  var sliderValue by remember { mutableStateOf(initialIndex) }
-
-  Row(
-    modifier = modifier,
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(8.dp)
-  ) {
-    Text(
-      text = "Limit:",
-      style = MaterialTheme.typography.labelSmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant
-    )
-    Slider(
-      value = sliderValue,
-      onValueChange = { sliderValue = it },
-      onValueChangeFinished = {
-        val idx = sliderValue.toInt()
-          .coerceIn(0, speedSteps.lastIndex)
-        val bps = speedSteps[idx]
-        val limit = if (bps == 0L) SpeedLimit.Unlimited
-        else SpeedLimit.of(bps)
-        scope.launch { task.setSpeedLimit(limit) }
-      },
-      valueRange = 0f..speedSteps.lastIndex.toFloat(),
-      steps = speedSteps.size - 2,
-      modifier = Modifier.weight(1f)
-    )
-    val idx = sliderValue.toInt()
-      .coerceIn(0, speedSteps.lastIndex)
-    Text(
-      text = if (speedSteps[idx] == 0L) "Unlimited"
-      else "${formatBytes(speedSteps[idx])}/s",
-      style = MaterialTheme.typography.labelSmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant
-    )
-  }
+  SpeedLimitSelector(
+    value = task.request.speedLimit,
+    onValueChange = { limit ->
+      scope.launch { task.setSpeedLimit(limit) }
+    },
+    modifier = modifier
+  )
 }


### PR DESCRIPTION
## Summary
- Replace slider-based speed limit panel with chip-based `SpeedLimitSelector` offering 9 presets (256 KB/s – 50 MB/s) plus custom input with KB/s / MB/s unit toggle
- Extract reusable `PrioritySelector` and `ScheduleSelector` composables from the task-bound panel variants
- Refactor `AddDownloadDialog` to use collapsed icon toggles (speed, priority, schedule) with expandable panels, matching the `DownloadListItem` pattern
- Add schedule support to the download creation flow (`AddDownloadDialog` → `AppState` → `DownloadRequest`)
- Auto-focus the URL text field when the dialog opens

## Test plan
- [x] Open Add Download dialog — URL field should be focused automatically
- [x] Verify icon toggle row shows speed, priority, and schedule icons
- [x] Click each icon to expand/collapse its panel; only one panel open at a time
- [x] Select various speed presets and verify they apply
- [x] Select "Custom" speed, enter a value, toggle KB/s ↔ MB/s
- [x] Change priority and schedule in the dialog, confirm download uses selected values
- [x] Verify per-task speed limit panel in download list uses the new chip-based selector
- [x] Test on Desktop (JVM) and Web (WasmJs) targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)