### PR TITLE
fix: prevent reschedule from causing Canceled state

### DIFF
--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/core/KDown.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/core/KDown.kt
@@ -246,10 +246,10 @@ class KDown(
               "conditions=${conditions.size}"
         }
         scheduleManager.cancel(taskId)
-        scheduler.dequeue(taskId)
         if (s.isActive) {
           coordinator.pause(taskId)
         }
+        scheduler.dequeue(taskId)
         scheduleManager.reschedule(
           taskId, request, schedule, conditions,
           now, stateFlow, segmentsFlow,
@@ -397,10 +397,10 @@ class KDown(
               "conditions=${conditions.size}"
         }
         scheduleManager.cancel(record.taskId)
-        scheduler.dequeue(record.taskId)
         if (s.isActive) {
           coordinator.pause(record.taskId)
         }
+        scheduler.dequeue(record.taskId)
         scheduleManager.reschedule(
           record.taskId, record.request, schedule, conditions,
           record.createdAt, stateFlow, segmentsFlow,

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/core/engine/DownloadScheduler.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/core/engine/DownloadScheduler.kt
@@ -207,9 +207,9 @@ internal class DownloadScheduler(
         }
       } else if (activeEntries.containsKey(taskId)) {
         removeActive(taskId)
-        coordinator.cancel(taskId)
         KDownLogger.i("Scheduler") {
-          "Canceled active download: taskId=$taskId"
+          "Removed active download from tracking: " +
+            "taskId=$taskId"
         }
         promoteNext()
       }


### PR DESCRIPTION
## Summary

- **Fixed race condition** where rescheduling an active download could leave the task in `Canceled` state
- `scheduler.dequeue()` was calling `coordinator.cancel()` for active tasks, which set `Canceled` state and cleared saved segments — inappropriate during reschedule
- `coordinator.pause()` set `Paused` *after* `job.cancel()`, allowing the `CancellationException` handler to transiently emit `Canceled` before `Paused` was set, which `monitorTaskState` could observe

## Changes

- Set `Paused` state before cancelling the job in `coordinator.pause()` to close the race window
- Remove `coordinator.cancel()` from `scheduler.dequeue()` — all callers already handle coordinator interactions separately
- Reorder `rescheduleAction` to pause the active download before dequeuing from the scheduler

## Test plan

- [ ] Reschedule an actively downloading task — verify it transitions to `Scheduled`, not `Canceled`
- [ ] Reschedule a queued task — verify it transitions to `Scheduled`
- [ ] Cancel a downloading task — verify it still transitions to `Canceled` correctly
- [ ] Pause and resume a download — verify segments are preserved
- [ ] Preempt a download with an URGENT task — verify the preempted task re-queues correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)