### PR TITLE
feat: use platform-specific default directories for downloads and database

### DIFF
--- a/app/android/src/main/kotlin/com/linroid/kdown/android/MainActivity.kt
+++ b/app/android/src/main/kotlin/com/linroid/kdown/android/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.linroid.kdown.android
 
 import android.os.Bundle
+import android.os.Environment
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -24,9 +25,14 @@ class MainActivity : ComponentActivity() {
         val taskStore = createSqliteTaskStore(
           DriverFactory(applicationContext)
         )
+        val downloadsDir = Environment
+          .getExternalStoragePublicDirectory(
+            Environment.DIRECTORY_DOWNLOADS
+          ).absolutePath
         BackendManager(
           BackendFactory(
             taskStore = taskStore,
+            defaultDirectory = downloadsDir,
             localServerFactory = { port, apiToken, kdownApi ->
               val server = KDownServer(
                 kdownApi,

--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/backend/BackendFactory.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/backend/BackendFactory.kt
@@ -27,8 +27,9 @@ import com.linroid.kdown.remote.RemoteKDown
  */
 class BackendFactory(
   taskStore: TaskStore? = null,
+  defaultDirectory: String = "downloads",
   private val embeddedFactory: (() -> KDownApi)? = taskStore?.let { ts ->
-    { createDefaultEmbeddedKDown(ts) }
+    { createDefaultEmbeddedKDown(ts, defaultDirectory) }
   },
   private val localServerFactory:
     ((port: Int, apiToken: String?, KDownApi) -> LocalServerHandle)? = null,
@@ -79,11 +80,13 @@ class BackendFactory(
 
 private fun createDefaultEmbeddedKDown(
   taskStore: TaskStore,
+  defaultDirectory: String,
 ): KDownApi {
   return KDown(
     httpEngine = KtorHttpEngine(),
     taskStore = taskStore,
     config = DownloadConfig(
+      defaultDirectory = defaultDirectory,
       maxConnections = 4,
       retryCount = 3,
       retryDelayMs = 1000,

--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/state/AppState.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/state/AppState.kt
@@ -138,7 +138,7 @@ class AppState(
         }
         val request = DownloadRequest(
           url = url,
-          directory = "downloads",
+          directory = null,
           fileName = fileName.ifBlank { null },
           connections = connections,
           speedLimit = speedLimit,

--- a/app/shared/src/iosMain/kotlin/com/linroid/kdown/app/MainViewController.kt
+++ b/app/shared/src/iosMain/kotlin/com/linroid/kdown/app/MainViewController.kt
@@ -7,15 +7,42 @@ import com.linroid.kdown.app.backend.BackendFactory
 import com.linroid.kdown.app.backend.BackendManager
 import com.linroid.kdown.sqlite.DriverFactory
 import com.linroid.kdown.sqlite.createSqliteTaskStore
+import platform.Foundation.NSApplicationSupportDirectory
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
 
 @Suppress("unused", "FunctionName")
 fun MainViewController() = ComposeUIViewController {
   val backendManager = remember {
-    val taskStore = createSqliteTaskStore(DriverFactory())
-    BackendManager(BackendFactory(taskStore = taskStore))
+    val dbPath = appSupportDbPath()
+    val taskStore = createSqliteTaskStore(DriverFactory(dbPath))
+    @Suppress("UNCHECKED_CAST")
+    val downloadsDir = (NSSearchPathForDirectoriesInDomains(
+      NSDocumentDirectory, NSUserDomainMask, true,
+    ) as List<String>).first()
+    BackendManager(
+      BackendFactory(
+        taskStore = taskStore,
+        defaultDirectory = downloadsDir,
+      )
+    )
   }
   DisposableEffect(Unit) {
     onDispose { backendManager.close() }
   }
   App(backendManager)
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun appSupportDbPath(): String {
+  val paths = NSSearchPathForDirectoriesInDomains(
+    NSApplicationSupportDirectory, NSUserDomainMask, true,
+  ) as List<String>
+  val dir = "${paths.first()}/kdown"
+  NSFileManager.defaultManager.createDirectoryAtPath(
+    dir, withIntermediateDirectories = true, attributes = null,
+  )
+  return "$dir/kdown.db"
 }

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/core/DownloadConfig.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/core/DownloadConfig.kt
@@ -5,6 +5,9 @@ import com.linroid.kdown.api.SpeedLimit
 /**
  * Download configuration.
  *
+ * @property defaultDirectory Default directory for saving downloaded files when
+ *   [DownloadRequest.directory][com.linroid.kdown.api.DownloadRequest.directory] is `null`.
+ *   Should be set to a platform-appropriate path by the app layer.
  * @property maxConnections Maximum number of concurrent segment downloads
  * @property retryCount Maximum number of retry attempts for failed requests
  * @property retryDelayMs Base delay in milliseconds between retry attempts (uses exponential backoff)
@@ -15,6 +18,7 @@ import com.linroid.kdown.api.SpeedLimit
  * @property queueConfig Configuration for the download queue
  */
 data class DownloadConfig(
+  val defaultDirectory: String = "downloads",
   val maxConnections: Int = 4,
   val retryCount: Int = 3,
   val retryDelayMs: Long = 1000,

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/core/engine/DownloadCoordinator.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/core/engine/DownloadCoordinator.kt
@@ -58,7 +58,7 @@ internal class DownloadCoordinator(
     segmentsFlow: MutableStateFlow<List<Segment>>,
   ) {
     val directory = request.directory?.let { Path(it) }
-      ?: error("directory is required for download")
+      ?: Path(config.defaultDirectory)
     val initialDestPath = request.fileName?.let {
       Path(directory, it)
     } ?: directory
@@ -206,7 +206,7 @@ internal class DownloadCoordinator(
         request, toServerInfo(resolvedUrl),
       )
     val dir = request.directory?.let { Path(it) }
-      ?: error("directory is required for download")
+      ?: Path(config.defaultDirectory)
     val destPath = deduplicatePath(dir, fileName)
 
     val now = Clock.System.now()

--- a/library/sqlite/src/iosMain/kotlin/com/linroid/kdown/sqlite/DriverFactory.ios.kt
+++ b/library/sqlite/src/iosMain/kotlin/com/linroid/kdown/sqlite/DriverFactory.ios.kt
@@ -3,8 +3,8 @@ package com.linroid.kdown.sqlite
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 
-actual class DriverFactory {
+actual class DriverFactory(private val dbPath: String) {
   actual fun createDriver(): SqlDriver {
-    return NativeSqliteDriver(KDownDatabase.Schema, "kdown.db")
+    return NativeSqliteDriver(KDownDatabase.Schema, dbPath)
   }
 }

--- a/library/sqlite/src/jvmMain/kotlin/com/linroid/kdown/sqlite/DriverFactory.jvm.kt
+++ b/library/sqlite/src/jvmMain/kotlin/com/linroid/kdown/sqlite/DriverFactory.jvm.kt
@@ -2,12 +2,14 @@ package com.linroid.kdown.sqlite
 
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import java.io.File
 
-actual class DriverFactory(private val dbPath: String = "kdown.db") {
+actual class DriverFactory(private val dbPath: String) {
   actual fun createDriver(): SqlDriver {
     val url = if (dbPath == ":memory:") {
       JdbcSqliteDriver.IN_MEMORY
     } else {
+      File(dbPath).parentFile?.mkdirs()
       "jdbc:sqlite:$dbPath"
     }
     val driver = JdbcSqliteDriver(url)


### PR DESCRIPTION
## Summary
- Add `defaultDirectory` field to `DownloadConfig` so the app layer provides platform-appropriate download paths instead of the hardcoded `"downloads"` relative path
- `DownloadCoordinator` now falls back to `config.defaultDirectory` when `DownloadRequest.directory` is null, matching its KDoc contract
- `DriverFactory` on JVM and iOS now requires an explicit `dbPath` — each app entry point provides the correct platform location:
  - **Android**: `Environment.DIRECTORY_DOWNLOADS` for downloads; db via `Context` (unchanged)
  - **macOS/Desktop**: `~/Downloads` for downloads; `~/Library/Application Support/kdown/kdown.db`
  - **Linux**: `~/Downloads`; `$XDG_CONFIG_HOME/kdown/kdown.db`
  - **Windows**: `~/Downloads`; `%APPDATA%\kdown\kdown.db`
  - **iOS**: Documents directory for downloads; `Application Support/kdown/kdown.db`

## Test plan
- [x] `./gradlew :library:core:compileKotlinJvm` passes
- [x] `./gradlew :library:sqlite:compileKotlinJvm` passes
- [x] `./gradlew :library:core:jvmTest` passes
- [x] `./gradlew :app:android:compileDebugKotlin` passes
- [x] `./gradlew :app:desktop:compileKotlin` passes
- [x] `./gradlew :cli:compileKotlin` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)