### PR TITLE
feat: add TOML config file support for CLI server

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   alias(libs.plugins.kotlinJvm)
+  alias(libs.plugins.kotlinx.serialization)
   application
 }
 
@@ -13,5 +14,7 @@ dependencies {
   implementation(projects.library.sqlite)
   implementation(projects.library.ktor)
   implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.ktoml.core)
   implementation(libs.ktor.client.cio)
 }

--- a/cli/src/main/kotlin/com/linroid/kdown/cli/CliConfig.kt
+++ b/cli/src/main/kotlin/com/linroid/kdown/cli/CliConfig.kt
@@ -1,0 +1,134 @@
+package com.linroid.kdown.cli
+
+import com.akuleshov7.ktoml.Toml
+import com.linroid.kdown.api.SpeedLimit
+import com.linroid.kdown.core.DownloadConfig
+import com.linroid.kdown.core.QueueConfig
+import com.linroid.kdown.server.KDownServerConfig
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.io.File
+
+@Serializable
+data class CliConfig(
+  val server: ServerSection = ServerSection(),
+  val download: DownloadSection = DownloadSection(),
+)
+
+@Serializable
+data class ServerSection(
+  val host: String = "0.0.0.0",
+  val port: Int = 8642,
+  @SerialName("api-token") val apiToken: String? = null,
+  @SerialName("cors-allowed-hosts") val corsAllowedHosts: List<String> = emptyList(),
+)
+
+@Serializable
+data class DownloadSection(
+  val directory: String? = null,
+  @SerialName("max-connections") val maxConnections: Int = 4,
+  @SerialName("retry-count") val retryCount: Int = 3,
+  @SerialName("retry-delay-ms") val retryDelayMs: Long = 1000,
+  @SerialName("progress-update-interval-ms") val progressUpdateIntervalMs: Long = 200,
+  @SerialName("segment-save-interval-ms") val segmentSaveIntervalMs: Long = 5000,
+  @SerialName("buffer-size") val bufferSize: Int = 8192,
+  @SerialName("speed-limit") val speedLimit: String? = null,
+  val queue: QueueSection = QueueSection(),
+)
+
+@Serializable
+data class QueueSection(
+  @SerialName("max-concurrent-downloads") val maxConcurrentDownloads: Int = 3,
+  @SerialName("max-connections-per-host") val maxConnectionsPerHost: Int = 4,
+  @SerialName("auto-start") val autoStart: Boolean = true,
+)
+
+fun CliConfig.toDownloadConfig(fallbackDir: String): DownloadConfig {
+  val speedLimit = download.speedLimit?.let { parseSpeedLimit(it) }
+    ?: SpeedLimit.Unlimited
+  return DownloadConfig(
+    defaultDirectory = download.directory ?: fallbackDir,
+    maxConnections = download.maxConnections,
+    retryCount = download.retryCount,
+    retryDelayMs = download.retryDelayMs,
+    progressUpdateIntervalMs = download.progressUpdateIntervalMs,
+    segmentSaveIntervalMs = download.segmentSaveIntervalMs,
+    bufferSize = download.bufferSize,
+    speedLimit = speedLimit,
+    queueConfig = QueueConfig(
+      maxConcurrentDownloads = download.queue.maxConcurrentDownloads,
+      maxConnectionsPerHost = download.queue.maxConnectionsPerHost,
+      autoStart = download.queue.autoStart,
+    ),
+  )
+}
+
+fun CliConfig.toServerConfig(): KDownServerConfig {
+  return KDownServerConfig(
+    host = server.host,
+    port = server.port,
+    apiToken = server.apiToken,
+    corsAllowedHosts = server.corsAllowedHosts,
+  )
+}
+
+fun loadConfig(path: String): CliConfig {
+  val file = File(path)
+  if (!file.exists()) {
+    throw IllegalArgumentException("Config file not found: $path")
+  }
+  val content = file.readText()
+  return Toml.decodeFromString(CliConfig.serializer(), content)
+}
+
+fun defaultConfigPath(): String {
+  val os = System.getProperty("os.name", "").lowercase()
+  val home = System.getProperty("user.home")
+  val configDir = when {
+    os.contains("mac") ->
+      "$home${File.separator}Library${File.separator}" +
+        "Application Support${File.separator}kdown"
+    os.contains("win") -> {
+      val appData = System.getenv("APPDATA")
+        ?: "$home${File.separator}AppData${File.separator}Roaming"
+      "$appData${File.separator}kdown"
+    }
+    else -> {
+      val xdg = System.getenv("XDG_CONFIG_HOME")
+        ?: "$home${File.separator}.config"
+      "$xdg${File.separator}kdown"
+    }
+  }
+  return File(configDir, "config.toml").absolutePath
+}
+
+private const val DEFAULT_CONFIG_CONTENT = """# KDown Server Configuration
+# Lines starting with # are comments.
+
+[server]
+host = "0.0.0.0"
+port = 8642
+# api-token = "my-secret"
+# cors-allowed-hosts = ["http://localhost:3000"]
+
+[download]
+# directory = "~/Downloads"
+# speed-limit = "10m"  # Suffixes: k = KB/s, m = MB/s, or raw bytes
+max-connections = 4
+retry-count = 3
+retry-delay-ms = 1000
+progress-update-interval-ms = 200
+segment-save-interval-ms = 5000
+buffer-size = 8192
+
+[download.queue]
+max-concurrent-downloads = 3
+max-connections-per-host = 4
+auto-start = true
+"""
+
+fun generateConfig(path: String) {
+  val file = File(path)
+  file.parentFile?.mkdirs()
+  file.writeText(DEFAULT_CONFIG_CONTENT)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ kotlinx-serialization = "1.10.0"
 kotlinx-io = "0.8.2"
 kotlinx-datetime = "0.7.1"
 kermit = "2.0.8"
+ktoml = "0.7.1"
 ktor = "3.4.0"
 sqldelight = "2.2.1"
 logback = "1.5.29"
@@ -72,6 +73,7 @@ ktor-serverResources = { module = "io.ktor:ktor-server-resources-jvm", version.r
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json-jvm", version.ref = "ktor" }
 ktor-serialization-json-common = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-serverTestHost = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
+ktoml-core = { module = "com.akuleshov7:ktoml-core", version.ref = "ktoml" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }


### PR DESCRIPTION
## Summary
- Add TOML config file support for the CLI `server` command using **ktoml** (`com.akuleshov7:ktoml-core:0.7.1`)
- New `--config <path>` flag to load configuration from an explicit TOML file
- New `--generate-config` flag to write a commented default config template and exit
- Auto-loads config from the platform default path (`~/Library/Application Support/kdown/config.toml` on macOS, `~/.config/kdown/config.toml` on Linux, `%APPDATA%\kdown\config.toml` on Windows) if it exists
- CLI flags always take precedence over config file values
- Config covers server settings (host, port, token, CORS), download settings (connections, retry, buffer, speed limit), and queue settings (concurrency, auto-start)

## Test plan
- [ ] `./gradlew cli:build` compiles successfully
- [ ] `./gradlew cli:run --args="server --generate-config"` creates a default config file
- [ ] Edit the generated config, then `./gradlew cli:run --args="server"` picks it up
- [ ] `./gradlew cli:run --args="server --config /path/to/config.toml"` uses explicit path
- [ ] `./gradlew cli:run --args="server --config /path/to/config.toml --port 9999"` — CLI flag overrides config file port
- [ ] Running `--generate-config` when file already exists shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)