### PR TITLE
fix: iOS build error from NSFileManager.createDirectoryAtPath

### DIFF
--- a/app/shared/src/iosMain/kotlin/com/linroid/kdown/app/MainViewController.kt
+++ b/app/shared/src/iosMain/kotlin/com/linroid/kdown/app/MainViewController.kt
@@ -7,9 +7,10 @@ import com.linroid.kdown.app.backend.BackendFactory
 import com.linroid.kdown.app.backend.BackendManager
 import com.linroid.kdown.sqlite.DriverFactory
 import com.linroid.kdown.sqlite.createSqliteTaskStore
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import platform.Foundation.NSApplicationSupportDirectory
 import platform.Foundation.NSDocumentDirectory
-import platform.Foundation.NSFileManager
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSUserDomainMask
 
@@ -41,8 +42,9 @@ private fun appSupportDbPath(): String {
     NSApplicationSupportDirectory, NSUserDomainMask, true,
   ) as List<String>
   val dir = "${paths.first()}/kdown"
-  NSFileManager.defaultManager.createDirectoryAtPath(
-    dir, withIntermediateDirectories = true, attributes = null,
-  )
+  val dirPath = Path(dir)
+  if (!SystemFileSystem.exists(dirPath)) {
+    SystemFileSystem.createDirectories(dirPath)
+  }
   return "$dir/kdown.db"
 }


### PR DESCRIPTION
## Summary
- Replace `NSFileManager.defaultManager.createDirectoryAtPath()` with `SystemFileSystem.createDirectories()` from kotlinx-io in the iOS `MainViewController`
- The ObjC `createDirectoryAtPath:withIntermediateDirectories:attributes:error:` method has interop issues with the `error:` parameter mapping in Kotlin 2.3.x, causing "None of the following candidates is applicable" compilation error
- Uses the same approach already used in `FileAccessor.ios.kt`

## Test plan
- [ ] iOS compilation succeeds on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)