### PR TITLE
feat: add log level control to Logger and CLI verbose flags

### DIFF
--- a/cli/src/main/kotlin/com/linroid/kdown/cli/CliConfig.kt
+++ b/cli/src/main/kotlin/com/linroid/kdown/cli/CliConfig.kt
@@ -19,8 +19,10 @@ data class CliConfig(
 data class ServerSection(
   val host: String = "0.0.0.0",
   val port: Int = 8642,
-  @SerialName("api-token") val apiToken: String? = null,
-  @SerialName("cors-allowed-hosts") val corsAllowedHosts: List<String> = emptyList(),
+  @SerialName("api-token")
+  val apiToken: String? = null,
+  @SerialName("cors-allowed-hosts")
+  val corsAllowedHosts: List<String> = emptyList(),
 )
 
 @Serializable

--- a/library/core/src/androidMain/kotlin/com/linroid/kdown/core/log/Logger.android.kt
+++ b/library/core/src/androidMain/kotlin/com/linroid/kdown/core/log/Logger.android.kt
@@ -2,24 +2,25 @@ package com.linroid.kdown.core.log
 
 import android.util.Log
 
-internal actual fun consoleLogger(): Logger = object : Logger {
-  override fun v(message: () -> String) {
-    Log.v("KDown", message())
-  }
+internal actual fun consoleLogger(minLevel: LogLevel): Logger =
+  object : Logger {
+    override fun v(message: () -> String) {
+      if (minLevel <= LogLevel.VERBOSE) Log.v("KDown", message())
+    }
 
-  override fun d(message: () -> String) {
-    Log.d("KDown", message())
-  }
+    override fun d(message: () -> String) {
+      if (minLevel <= LogLevel.DEBUG) Log.d("KDown", message())
+    }
 
-  override fun i(message: () -> String) {
-    Log.i("KDown", message())
-  }
+    override fun i(message: () -> String) {
+      if (minLevel <= LogLevel.INFO) Log.i("KDown", message())
+    }
 
-  override fun w(message: () -> String, throwable: Throwable?) {
-    Log.w("KDown", message(), throwable)
-  }
+    override fun w(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.WARN) Log.w("KDown", message(), throwable)
+    }
 
-  override fun e(message: () -> String, throwable: Throwable?) {
-    Log.e("KDown", message(), throwable)
+    override fun e(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.ERROR) Log.e("KDown", message(), throwable)
+    }
   }
-}

--- a/library/core/src/commonMain/kotlin/com/linroid/kdown/core/log/Logger.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/kdown/core/log/Logger.kt
@@ -1,6 +1,16 @@
 package com.linroid.kdown.core.log
 
 /**
+ * Log level for filtering log output.
+ *
+ * Messages at or above the configured level are emitted;
+ * messages below are discarded without evaluating the lambda.
+ */
+enum class LogLevel {
+  VERBOSE, DEBUG, INFO, WARN, ERROR
+}
+
+/**
  * Logger abstraction for KDown.
  *
  * KDown supports pluggable logging with zero overhead when disabled (default).
@@ -18,6 +28,14 @@ package com.linroid.kdown.core.log
  * val kdown = KDown(
  *   httpEngine = KtorHttpEngine(),
  *   logger = Logger.console()  // Platform-specific console output
+ * )
+ * ```
+ *
+ * ### Console Logging with Level Filter
+ * ```kotlin
+ * val kdown = KDown(
+ *   httpEngine = KtorHttpEngine(),
+ *   logger = Logger.console(LogLevel.INFO)  // Only INFO and above
  * )
  * ```
  *
@@ -103,15 +121,18 @@ interface Logger {
     }
 
     /**
-     * Simple console logger that prints all messages to stdout/stderr.
+     * Simple console logger that prints messages to stdout/stderr.
      * Useful for quick debugging or CLI applications.
      * Platform-specific implementation.
+     *
+     * @param minLevel minimum log level to emit (default: [LogLevel.VERBOSE])
      */
-    fun console(): Logger = consoleLogger()
+    fun console(minLevel: LogLevel = LogLevel.VERBOSE): Logger =
+      consoleLogger(minLevel)
   }
 }
 
 /**
  * Platform-specific console logger implementation.
  */
-internal expect fun consoleLogger(): Logger
+internal expect fun consoleLogger(minLevel: LogLevel): Logger

--- a/library/core/src/iosMain/kotlin/com/linroid/kdown/core/log/Logger.ios.kt
+++ b/library/core/src/iosMain/kotlin/com/linroid/kdown/core/log/Logger.ios.kt
@@ -1,31 +1,36 @@
 package com.linroid.kdown.core.log
 
-internal actual fun consoleLogger(): Logger = object : Logger {
-  override fun v(message: () -> String) {
-    println("[VERBOSE] ${message()}")
-  }
+internal actual fun consoleLogger(minLevel: LogLevel): Logger =
+  object : Logger {
+    override fun v(message: () -> String) {
+      if (minLevel <= LogLevel.VERBOSE) println("[VERBOSE] ${message()}")
+    }
 
-  override fun d(message: () -> String) {
-    println("[DEBUG] ${message()}")
-  }
+    override fun d(message: () -> String) {
+      if (minLevel <= LogLevel.DEBUG) println("[DEBUG] ${message()}")
+    }
 
-  override fun i(message: () -> String) {
-    println("[INFO] ${message()}")
-  }
+    override fun i(message: () -> String) {
+      if (minLevel <= LogLevel.INFO) println("[INFO] ${message()}")
+    }
 
-  override fun w(message: () -> String, throwable: Throwable?) {
-    println("[WARN] ${message()}")
-    throwable?.let {
-      println("  Exception: ${it.message}")
-      println("  ${it.stackTraceToString()}")
+    override fun w(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.WARN) {
+        println("[WARN] ${message()}")
+        throwable?.let {
+          println("  Exception: ${it.message}")
+          println("  ${it.stackTraceToString()}")
+        }
+      }
+    }
+
+    override fun e(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.ERROR) {
+        println("[ERROR] ${message()}")
+        throwable?.let {
+          println("  Exception: ${it.message}")
+          println("  ${it.stackTraceToString()}")
+        }
+      }
     }
   }
-
-  override fun e(message: () -> String, throwable: Throwable?) {
-    println("[ERROR] ${message()}")
-    throwable?.let {
-      println("  Exception: ${it.message}")
-      println("  ${it.stackTraceToString()}")
-    }
-  }
-}

--- a/library/core/src/jvmMain/kotlin/com/linroid/kdown/core/log/Logger.jvm.kt
+++ b/library/core/src/jvmMain/kotlin/com/linroid/kdown/core/log/Logger.jvm.kt
@@ -1,25 +1,30 @@
 package com.linroid.kdown.core.log
 
-internal actual fun consoleLogger(): Logger = object : Logger {
-  override fun v(message: () -> String) {
-    println("[VERBOSE] ${message()}")
-  }
+internal actual fun consoleLogger(minLevel: LogLevel): Logger =
+  object : Logger {
+    override fun v(message: () -> String) {
+      if (minLevel <= LogLevel.VERBOSE) println("[VERBOSE] ${message()}")
+    }
 
-  override fun d(message: () -> String) {
-    println("[DEBUG] ${message()}")
-  }
+    override fun d(message: () -> String) {
+      if (minLevel <= LogLevel.DEBUG) println("[DEBUG] ${message()}")
+    }
 
-  override fun i(message: () -> String) {
-    println("[INFO] ${message()}")
-  }
+    override fun i(message: () -> String) {
+      if (minLevel <= LogLevel.INFO) println("[INFO] ${message()}")
+    }
 
-  override fun w(message: () -> String, throwable: Throwable?) {
-    println("[WARN] ${message()}")
-    throwable?.printStackTrace()
-  }
+    override fun w(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.WARN) {
+        println("[WARN] ${message()}")
+        throwable?.printStackTrace()
+      }
+    }
 
-  override fun e(message: () -> String, throwable: Throwable?) {
-    System.err.println("[ERROR] ${message()}")
-    throwable?.printStackTrace()
+    override fun e(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.ERROR) {
+        System.err.println("[ERROR] ${message()}")
+        throwable?.printStackTrace()
+      }
+    }
   }
-}

--- a/library/core/src/wasmJsMain/kotlin/com/linroid/kdown/core/log/Logger.wasmJs.kt
+++ b/library/core/src/wasmJsMain/kotlin/com/linroid/kdown/core/log/Logger.wasmJs.kt
@@ -1,31 +1,36 @@
 package com.linroid.kdown.core.log
 
-internal actual fun consoleLogger(): Logger = object : Logger {
-  override fun v(message: () -> String) {
-    println("[VERBOSE] ${message()}")
-  }
+internal actual fun consoleLogger(minLevel: LogLevel): Logger =
+  object : Logger {
+    override fun v(message: () -> String) {
+      if (minLevel <= LogLevel.VERBOSE) println("[VERBOSE] ${message()}")
+    }
 
-  override fun d(message: () -> String) {
-    println("[DEBUG] ${message()}")
-  }
+    override fun d(message: () -> String) {
+      if (minLevel <= LogLevel.DEBUG) println("[DEBUG] ${message()}")
+    }
 
-  override fun i(message: () -> String) {
-    println("[INFO] ${message()}")
-  }
+    override fun i(message: () -> String) {
+      if (minLevel <= LogLevel.INFO) println("[INFO] ${message()}")
+    }
 
-  override fun w(message: () -> String, throwable: Throwable?) {
-    println("[WARN] ${message()}")
-    throwable?.let {
-      println("  Exception: ${it.message}")
-      println("  ${it.stackTraceToString()}")
+    override fun w(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.WARN) {
+        println("[WARN] ${message()}")
+        throwable?.let {
+          println("  Exception: ${it.message}")
+          println("  ${it.stackTraceToString()}")
+        }
+      }
+    }
+
+    override fun e(message: () -> String, throwable: Throwable?) {
+      if (minLevel <= LogLevel.ERROR) {
+        println("[ERROR] ${message()}")
+        throwable?.let {
+          println("  Exception: ${it.message}")
+          println("  ${it.stackTraceToString()}")
+        }
+      }
     }
   }
-
-  override fun e(message: () -> String, throwable: Throwable?) {
-    println("[ERROR] ${message()}")
-    throwable?.let {
-      println("  Exception: ${it.message}")
-      println("  ${it.stackTraceToString()}")
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- Add `LogLevel` enum (`VERBOSE`, `DEBUG`, `INFO`, `WARN`, `ERROR`) to `library:core` Logger API
- `Logger.console(minLevel)` now filters messages below the configured level without evaluating the lambda
- CLI defaults to `INFO` log level; use `-v`/`--verbose` for DEBUG or `--debug` for TRACE
- Both logback (Ktor/framework logs) and KDown's `Logger.console()` respect the CLI flag
- Remove unused `--queue-demo` subcommand

## Test plan
- [ ] `kdown server --port 9000 --dir /tmp/downloads` — only INFO+ logs from KDown
- [ ] `kdown -v server --port 9000 --dir /tmp/downloads` — DEBUG+ logs visible
- [ ] `kdown --debug server --port 9000 --dir /tmp/downloads` — all logs including VERBOSE
- [ ] `Logger.console()` without arguments still logs everything (backward compat)
- [ ] `Logger.console(LogLevel.WARN)` only emits WARN and ERROR

🤖 Generated with [Claude Code](https://claude.com/claude-code)