### PR TITLE
chore: reduce CLI native image size with GraalVM flags and UPX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,18 @@ jobs:
       - name: Build native image
         run: ./gradlew :cli:nativeCompile -PVERSION_NAME=${KDOWN_VERSION#v}
 
+      - name: Compress with UPX (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y upx-ucl
+          upx --best cli/build/native/nativeCompile/kdown
+
+      - name: Compress with UPX (Windows)
+        if: matrix.os == 'windows'
+        run: |
+          choco install upx -y
+          upx --best cli/build/native/nativeCompile/kdown.exe
+
       - name: Package (Unix)
         if: matrix.os != 'windows'
         run: |

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -23,6 +23,8 @@ graalvmNative {
       )
       buildArgs.addAll(
         "--no-fallback",
+        "-Os",
+        "-H:+StripDebugInfo",
         "-H:+ReportExceptionStackTraces",
         "--initialize-at-build-time=io.ktor,kotlin,kotlinx.coroutines,kotlinx.serialization,kotlinx.io",
         "--initialize-at-build-time=ch.qos.logback",


### PR DESCRIPTION
## Summary
- Add `-Os` (optimize for size) and `-H:+StripDebugInfo` (strip debug symbols) to GraalVM native-image build args in `cli/build.gradle.kts`
- Add UPX compression (`upx --best`) in release workflow for Linux and Windows binaries (macOS skipped due to Gatekeeper/code signing issues)
- Expected total size reduction: ~60-70%

## Test plan
- [ ] `./gradlew :cli:nativeCompile` builds successfully with new flags
- [ ] Resulting binary runs correctly (`kdown --help`)
- [ ] Release workflow succeeds on Linux, Windows, and macOS matrix jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)