### PR TITLE
Show add-remote-server dialog when no backend is available

### DIFF
--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/state/AppState.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/state/AppState.kt
@@ -108,9 +108,7 @@ class AppState(
   var errorMessage by mutableStateOf<String?>(null)
   var showAddDialog by mutableStateOf(false)
   var showInstanceSelector by mutableStateOf(false)
-  var showAddRemoteDialog by mutableStateOf(
-    activeInstance.value == null
-  )
+  var showAddRemoteDialog by mutableStateOf(false)
 
   /**
    * Handle "New Task" action. If no backend is available,

--- a/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/AppShell.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/kdown/app/ui/AppShell.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -65,6 +66,15 @@ fun AppShell(instanceManager: InstanceManager) {
 
   DisposableEffect(Unit) {
     onDispose { instanceManager.close() }
+  }
+
+  val instances by appState.instances.collectAsState()
+  // Auto-show add-remote-server dialog when no instances
+  // are configured (remote-only mode without auto-connect).
+  LaunchedEffect(instances) {
+    if (instances.isEmpty()) {
+      appState.showAddRemoteDialog = true
+    }
   }
 
   val sortedTasks by appState.sortedTasks.collectAsState()


### PR DESCRIPTION
When the user clicks "New Task" and no instance is connected
(remote-only mode with no server configured), redirect to the
add-remote-server dialog instead of showing the download dialog
that would fail on resolve/download.

https://claude.ai/code/session_013LCqoKt9Kw6FyQyY2nx3vy